### PR TITLE
show assists in kill feed + friendly/neutral colors (#15)

### DIFF
--- a/dlls/CBaseEntity.cpp
+++ b/dlls/CBaseEntity.cpp
@@ -98,6 +98,11 @@ int CBaseEntity::TakeDamage(entvars_t* pevInflictor, entvars_t* pevAttacker, flo
 	if (pev->health <= 0)
 	{
 		Killed(pevAttacker, GIB_NORMAL);
+
+		if (IsMonster()) {
+			g_pGameRules->DeathNotice((CBaseMonster*)this, pevAttacker, pevInflictor);
+		}
+
 		return 0;
 	}
 

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -30,7 +30,8 @@ extern void GameDLLInit( void );
 #define DEFAULT_TEAM_NAME "Team" // name seen in the scoreboard
 #define DEFAULT_TEAM_COLOR 1
 #define ENEMY_TEAM_COLOR 2
-#define WORLD_TEAM_COLOR 3
+#define NEUTRAL_TEAM_COLOR 3
+#define FRIEND_TEAM_COLOR 4
 #define OBSERVER_TEAM_COLOR 6 // spectator color (white on windows, still blue on linux?)
 
 extern cvar_t	displaysoundlist;
@@ -65,7 +66,7 @@ extern cvar_t	mp_survival_supported;
 extern cvar_t	mp_survival_starton;
 extern cvar_t	mp_survival_restart;
 extern cvar_t	mp_mergemodels; // used merged models to save on model slots
-extern cvar_t	mp_killfeed; // 0 = off, 1 = player deaths, 2 = show monster deaths
+extern cvar_t	mp_killfeed; // 0 = off, 1 = player deaths, 2 = show monster deaths, 3 = show assists
 
 // Enables classic func_pushable physics (which is horribly broken, but fun)
 // The higher your FPS, the faster you can boost pushables. You also get boosted.

--- a/dlls/monster/CBaseMonster.h
+++ b/dlls/monster/CBaseMonster.h
@@ -21,6 +21,11 @@ extern entvars_t* g_pevLastInflictor;
 // Clients can push talkmonsters out of their way
 #define		bits_COND_CLIENT_PUSH		( bits_COND_SPECIAL1 )
 
+struct PlayerAttackInfo {
+	int userid; // 0 = free slot
+	float damageDealt;
+};
+
 //
 // generic Monster
 //
@@ -150,6 +155,8 @@ public:
 
 	int m_lastDamageType;
 	EHANDLE m_lastDamageEnt;
+
+	PlayerAttackInfo m_attackers[32]; // players that attacked this entity
 
 	virtual int		GetEntindexPriority() { return ENTIDX_PRIORITY_HIGH; }
 	virtual int		ObjectCaps(void) { return CBaseEntity::ObjectCaps() | FCAP_IMPULSE_USE; }
@@ -417,6 +424,7 @@ public:
 	void SetHealth();
 	void InitModel();
 	virtual void Nerf(); // reduces monster health and/or spawn count according to cvars
+	void LogPlayerDamage(entvars_t* attacker, float damage);
 };
 
 

--- a/dlls/triggers/CGamePlayerZone.cpp
+++ b/dlls/triggers/CGamePlayerZone.cpp
@@ -4,6 +4,7 @@
 #include "gamerules.h"
 #include "cbase.h"
 #include "CRuleEntity.h"
+#include "CBasePlayer.h"
 
 //
 // CGamePlayerZone / game_player_zone -- players in the zone fire my target when I'm fired
@@ -71,7 +72,7 @@ void CGamePlayerZone::Use(CBaseEntity* pActivator, CBaseEntity* pCaller, USE_TYP
 	if (!CanFireForActivator(pActivator))
 		return;
 
-	CBaseEntity* pPlayer = NULL;
+	CBasePlayer* pPlayer = NULL;
 
 	for (int i = 1; i <= gpGlobals->maxClients; i++)
 	{

--- a/dlls/util.cpp
+++ b/dlls/util.cpp
@@ -651,20 +651,38 @@ CBaseEntity *UTIL_FindEntityGeneric( const char *szWhatever, Vector &vecSrc, flo
 // returns a CBaseEntity pointer to a player by index.  Only returns if the player is spawned and connected
 // otherwise returns NULL
 // Index is 1 based
-CBaseEntity	*UTIL_PlayerByIndex( int playerIndex )
+CBasePlayer* UTIL_PlayerByIndex( int playerIndex )
 {
-	CBaseEntity *pPlayer = NULL;
+	CBasePlayer* pPlayer = NULL;
 
 	if ( playerIndex > 0 && playerIndex <= gpGlobals->maxClients )
 	{
 		edict_t *pPlayerEdict = INDEXENT( playerIndex );
 		if ( IsValidPlayer(pPlayerEdict) && !pPlayerEdict->free )
 		{
-			pPlayer = CBaseEntity::Instance( pPlayerEdict );
+			pPlayer = (CBasePlayer*)CBaseEntity::Instance( pPlayerEdict );
 		}
 	}
 	
 	return pPlayer;
+}
+
+CBasePlayer* UTIL_PlayerByUserId(int userid)
+{
+	CBasePlayer* pPlayer = NULL;
+
+	if (userid > 0)
+	{
+		for (int i = 1; i <= gpGlobals->maxClients; i++)
+		{
+			CBasePlayer* pPlayer = UTIL_PlayerByIndex(i);
+
+			if (pPlayer && g_engfuncs.pfnGetPlayerUserId(pPlayer->edict()) == userid)
+				return pPlayer;
+		}
+	}
+
+	return NULL;
 }
 
 edict_t* UTIL_ClientsInPVS(edict_t* edict, int& playerCount) {

--- a/dlls/util.h
+++ b/dlls/util.h
@@ -40,6 +40,8 @@
 #include "shared_util.h"
 #include "studio.h"
 
+class CBasePlayer;
+
 inline void MESSAGE_BEGIN( int msg_dest, int msg_type, const float *pOrigin, entvars_t *ent );  // implementation later in this file
 
 struct WavInfo {
@@ -314,7 +316,8 @@ EXPORT CBaseEntity	*UTIL_FindEntityGeneric(const char *szName, Vector &vecSrc, f
 // returns a CBaseEntity pointer to a player by index.  Only returns if the player is spawned and connected
 // otherwise returns NULL
 // Index is 1 based
-extern CBaseEntity	*UTIL_PlayerByIndex( int playerIndex );
+extern CBasePlayer	*UTIL_PlayerByIndex( int playerIndex );
+extern CBasePlayer	*UTIL_PlayerByUserId( int userid );
 
 #define UTIL_EntitiesInPVS(pent)			(*g_engfuncs.pfnEntitiesInPVS)(pent)
 EXPORT edict_t*		UTIL_ClientsInPVS(edict_t* edict, int& playerCount);


### PR DESCRIPTION
friendly npcs have green names in the kill feed, neutral npcs have yellow. Set mp_killfeed to 3 to show assists (e.g. "w00tguy + MaxKek killed Apache")