### PR TITLE
suit voice fix + tweaks

### DIFF
--- a/dlls/item/CItemBattery.cpp
+++ b/dlls/item/CItemBattery.cpp
@@ -80,7 +80,8 @@ class CItemBattery : public CItem
 			if (pct > 0)
 				pct--;
 
-			snprintf(szcharge, 64, "!HEV_%1dP", pct);
+			if (pct > 0)
+				snprintf(szcharge, 64, "!HEV_%1dP", pct);
 
 			//EMIT_SOUND_SUIT(ENT(pev), szcharge);
 			pPlayer->SetSuitUpdate(szcharge, FALSE, SUIT_NEXT_IN_30SEC);

--- a/dlls/monster/CBodyGuard.cpp
+++ b/dlls/monster/CBodyGuard.cpp
@@ -440,8 +440,10 @@ Schedule_t* CBodyGuard::GetScheduleOfType(int Type)
 		}
 		return &slGruntRangeAttack1C[0]; // prevent crouching or angry idle animations
 	default:
-		return wasSpinning ? &slMinigunSpindown[0] : CBaseGrunt::GetScheduleOfType(Type);
+		break;
 	}
+
+	return wasSpinning ? &slMinigunSpindown[0] : CBaseGrunt::GetScheduleOfType(Type);
 }
 
 int CBodyGuard::GetActivitySequence(Activity NewActivity) {

--- a/dlls/weapon/CDisplacer.cpp
+++ b/dlls/weapon/CDisplacer.cpp
@@ -367,7 +367,7 @@ void CDisplacer::FireThink()
 
 	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] == 0)
 	{
-		m_pPlayer->SetSuitUpdate("!HEV_AMO0", TRUE, SUIT_REPEAT_OK);
+		m_pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, SUIT_REPEAT_OK);
 	}
 #endif
 
@@ -476,7 +476,7 @@ void CDisplacer::AltFireThink()
 		//if (0 == GetMagazine1())
 		{
 			if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
-				m_pPlayer->SetSuitUpdate("!HEV_AMO0", TRUE, SUIT_REPEAT_OK);
+				m_pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, SUIT_REPEAT_OK);
 		}
 
 		m_flTimeWeaponIdle = UTIL_WeaponTimeBase();

--- a/dlls/weapon/CEgon.cpp
+++ b/dlls/weapon/CEgon.cpp
@@ -125,6 +125,10 @@ void CEgon::Holster( int skiplocal /* = 0 */ )
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5;
 	SendWeaponAnim( EGON_HOLSTER );
 
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] == 0) {
+		m_pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, SUIT_REPEAT_OK);
+	}
+
     EndAttack();
 }
 

--- a/dlls/weapon/CGauss.cpp
+++ b/dlls/weapon/CGauss.cpp
@@ -150,6 +150,10 @@ void CGauss::Holster( int skiplocal /* = 0 */ )
 	
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + 0.5;
 	
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] == 0) {
+		m_pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, SUIT_REPEAT_OK);
+	}
+
 	SendWeaponAnim( GAUSS_HOLSTER );
 	m_fInAttack = 0;
 }

--- a/dlls/weapon/CRpg.cpp
+++ b/dlls/weapon/CRpg.cpp
@@ -575,6 +575,10 @@ void CRpg::Holster( int skiplocal /* = 0 */ )
 	
 	SendWeaponAnim( RPG_HOLSTER1 );
 
+	if (m_iClip == 0 && m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] == 0) {
+		m_pPlayer->SetSuitUpdate("!HEV_AMO0", FALSE, SUIT_REPEAT_OK);
+	}
+
 #ifndef CLIENT_DLL
 	CLaserSpot* m_pSpot = (CLaserSpot*)m_hSpot.GetEntity();
 	if (m_pSpot)


### PR DESCRIPTION
- fix voice queue not cleared on respawn
- fix batteries given at spawn triggering the suit voice
- deduplicate battery level messages (at most 1 in queue and 1 playing)
- play "power level less than 5%" warning when flashlight is low, not when getting a bit of armor
- add "ammo depleted" messages for egon, gauss, rpg and displacer
- add "extreme heat damage" for swimming in lava
- add "armor compromised" when armor is hits 0%
- add "hev damage sustained" when armor is hit for 50+ points at once

also fix a warning