### PR TITLE
cleanup old corpses

### DIFF
--- a/dlls/game/game.cpp
+++ b/dlls/game/game.cpp
@@ -78,6 +78,7 @@ cvar_t	mp_min_score_mult ={"mp_min_score_mult", "20", FCVAR_SERVER, 0, 0 };
 cvar_t	mp_hevsuit_voice ={"mp_hevsuit_voice", "0", FCVAR_SERVER, 0, 0 };
 cvar_t	npc_dropweapons ={"npc_dropweapons", "1", FCVAR_SERVER, 0, 0 };
 cvar_t	mp_bigmap ={"mp_bigmap", "0", FCVAR_SERVER, 0, 0 };
+cvar_t	mp_max_pvs_corpses ={"mp_max_pvs_corpses", "32", FCVAR_SERVER, 0, 0 };
 
 cvar_t	soundvariety={"mp_soundvariety","0", FCVAR_SERVER, 0, 0 };
 cvar_t	mp_npcidletalk={"mp_npcidletalk","1", FCVAR_SERVER, 0, 0 };
@@ -444,6 +445,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER (&mp_hevsuit_voice);
 	CVAR_REGISTER (&npc_dropweapons);
 	CVAR_REGISTER (&mp_bigmap);
+	CVAR_REGISTER (&mp_max_pvs_corpses);
 
 	CVAR_REGISTER (&mp_chattime);
 

--- a/dlls/game/game.h
+++ b/dlls/game/game.h
@@ -81,6 +81,7 @@ EXPORT extern cvar_t	mp_min_score_mult; // minimum score multiplier for death pe
 EXPORT extern cvar_t	mp_hevsuit_voice; // enable/disable the hev suit voice
 EXPORT extern cvar_t	npc_dropweapons; // enable/disable npcs dropping weapons
 EXPORT extern cvar_t	mp_bigmap; // precaches models/sounds so common effects can work outside +/-4096
+EXPORT extern cvar_t	mp_max_pvs_corpses; // limit number of corpses in a VIS zone
 
 // Enables classic func_pushable physics (which is horribly broken, but fun)
 // The higher your FPS, the faster you can boost pushables. You also get boosted.

--- a/dlls/hooks/hlds_hooks.cpp
+++ b/dlls/hooks/hlds_hooks.cpp
@@ -2248,6 +2248,15 @@ edict_t* SpawnEdict(edict_t* pent) {
 			REMOVE_ENTITY(pent);
 			return NULL;
 		}
+
+		// cleanup up dead things and items if we're about to overflow edicts for some players
+		int cleanupEntBegin = MAX_LEGACY_CLIENT_ENTS - 65; // give some time for corpses to fade out
+		int removeCount = pEntity->entindex() - cleanupEntBegin;
+		if (pEntity->GetEntindexPriority() == ENTIDX_PRIORITY_NORMAL && removeCount > 0) {
+			ALERT(at_console, "Cleanup %d ents because %s got high index %d\n",
+				removeCount, STRING(pEntity->pev->classname), pEntity->entindex());
+			UTIL_CleanupEntities(removeCount);
+		}
 	}
 
 	// Handle global stuff here

--- a/dlls/monster/CBaseMonster.h
+++ b/dlls/monster/CBaseMonster.h
@@ -185,6 +185,8 @@ public:
 
 	int m_flinchChance; // 0-100 chance the HEAVY_DAMAGE condition is set (0 = 100, -1 = 0)
 
+	float m_killedTime; // time monster became dead
+
 	virtual int		ObjectCaps(void) { return CBaseEntity::ObjectCaps() | FCAP_IMPULSE_USE; }
 	virtual int		Save( CSave &save ); 
 	virtual int		Restore( CRestore &restore );
@@ -486,6 +488,9 @@ public:
 	virtual int IRelationship(CBaseEntity* pTarget) override;
 
 	void UpdateOnRemove(void) override;
+
+	// scan for other corpses in this corpes' PVS and remove them if over the limit
+	void CleanupLocalCorpses();
 };
 
 

--- a/dlls/util/util.cpp
+++ b/dlls/util/util.cpp
@@ -2318,6 +2318,32 @@ CBaseEntity* RelocateEntIdx(CBaseEntity* pEntity) {
 	return pEntity;
 }
 
+void UTIL_CleanupEntities(int removeCount) {
+	std::vector<CBaseMonster*> corpses;
+
+	CBaseEntity* ent = NULL;
+	float bestCorpseTime = FLT_MAX;
+	while ((ent = UTIL_FindEntityByClassname(ent, "monster_*")) != NULL) {
+		CBaseMonster* mon = ent->MyMonsterPointer();
+
+		if (!mon || !mon->IsNormalMonster() || !mon->m_killedTime || mon->m_isFadingOut) {
+			continue;
+		}
+
+		corpses.push_back(mon);
+	}
+
+	std::sort(corpses.begin(), corpses.end(), [](const CBaseMonster* a, const CBaseMonster* b) {
+		return a->m_killedTime < b->m_killedTime;
+	});
+
+	for (int i = 0; i < removeCount && i < corpses.size(); i++) {
+		corpses[i]->SUB_StartFadeOut();
+	}
+
+	ALERT(at_console, "Faded %d old corpses\n", V_min(corpses.size(), removeCount));
+}
+
 edict_t* CREATE_NAMED_ENTITY(string_t cname) {
 	edict_t* ed = g_engfuncs.pfnCreateNamedEntity(cname);
 

--- a/dlls/util/util.h
+++ b/dlls/util/util.h
@@ -791,6 +791,9 @@ EXPORT void InitEdictRelocations();
 EXPORT void PrintEntindexStats(bool showCounts=false);
 EXPORT CBaseEntity* RelocateEntIdx(CBaseEntity* pEntity);
 
+// removes the oldest corpses/gibs/weaponboxes
+EXPORT void UTIL_CleanupEntities(int removeCount);
+
 // returns false if the entity index would overflow the client, and prints an error message in that case
 EXPORT bool UTIL_isSafeEntIndex(edict_t* plr, int idx, const char* action);
 


### PR DESCRIPTION
if the edict count is about to exceed legacy client limits or if too many corpses are in a VIS area, then old corpses are removed.